### PR TITLE
Fixed test dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,15 +61,16 @@ val cakeServer = (project in file("cake-server"))
   .settings(
     name := "cake-weather-server",
     libraryDependencies ++= Seq(
-      "org.mockito" % "mockito-core" % "1.10.19" % "test")
+      "org.mockito" % "mockito-core" % "1.10.19" % "test"
+    )
   )
-  .dependsOn(common)
+  .dependsOn(common % "compile->compile;test->test")
 
 val freeServer = (project in file("free-server"))
   .enablePlugins(AutomateHeaderPlugin)
   .settings(commonSettings)
   .settings(name := "free-weather-server")
-  .dependsOn(common)
+  .dependsOn(common % "compile->compile;test->test")
 
 val root = (project in file("."))
   .settings(commonSettings)


### PR DESCRIPTION
This fixes couple of errors:
```
[error] /home/ilya/ScalaProjects/scala-cats-free-monads-example/cake-server/src/test/scala/com/lunaryorn/weather/cake/TemperatureServiceComponentSpec.scala:28: object prop is not a member of package com.lunaryorn.weather
[error] import com.lunaryorn.weather.prop._
[error]  
```
```
[error] /home/ilya/ScalaProjects/scala-cats-free-monads-example/cake-server/src/test/scala/com/lunaryorn/weather/cake/TemperatureServiceComponentSpec.scala:50: could not find implicit value for parameter arbA: org.scalacheck.Arbitrary[Seq[squants.Temperature]]
[error]         forAll { temperatures: Seq[Temperature] =>
[error]                ^
[error] /home/ilya/ScalaProjects/scala-cats-free-monads-example/cake-server/src/test/scala/com/lunaryorn/weather/cake/TemperatureServiceComponentSpec.scala:59: could not find implicit value for parameter arbA: org.scalacheck.Arbitrary[squants.Temperature]
[error]         forAll { temperature: Temperature =>
[error]                ^
[error] /home/ilya/ScalaProjects/scala-cats-free-monads-example/cake-server/src/test/scala/com/lunaryorn/weather/cake/TemperatureServiceComponentSpec.scala:76: could not find implicit value for parameter arbA: org.scalacheck.Arbitrary[squants.Temperature]
[error]         forAll {
[error]                ^
[error] four errors found
```